### PR TITLE
Simple extension to set the log level for exiv2

### DIFF
--- a/exiv.go
+++ b/exiv.go
@@ -105,6 +105,21 @@ func OpenBytes(input []byte) (*Image, error) {
 	return makeImage(cimg, bytesArrayPtr), nil
 }
 
+type LogMsgLevel int
+
+const (
+	LogMsgDebug LogMsgLevel = 0
+	LogMsgInfo              = 1
+	LogMsgWarn              = 2
+	LogMsgError             = 3
+	LogMsgMute              = 4
+)
+
+// SetLogMsgLevel Set the log level (outputs to stderr)
+func SetLogMsgLevel(level LogMsgLevel) {
+	C.exiv2_log_msg_set_level(C.int(level))
+}
+
 // ReadMetadata reads the metadata of an Image
 func (i *Image) ReadMetadata() error {
 	var cerr *C.Exiv2Error

--- a/helper.cpp
+++ b/helper.cpp
@@ -416,6 +416,15 @@ const char* exiv2_exif_datum_to_string(const Exiv2ExifDatum *datum)
 
 DEFINE_FREE_FUNCTION(exiv2_exif_datum, Exiv2ExifDatum*);
 
+// LOG LEVEL
+
+void
+exiv2_log_msg_set_level(const int level)
+{
+    Exiv2::LogMsg::Level cpplevel = static_cast<Exiv2::LogMsg::Level>(level);
+    Exiv2::LogMsg::setLevel(cpplevel);
+}
+
 // ERRORS
 
 int

--- a/helper.h
+++ b/helper.h
@@ -64,6 +64,8 @@ Exiv2ExifDatum* exiv2_exif_datum_iterator_next(Exiv2ExifDatumIterator *iter);
 const unsigned char* exiv2_image_icc_profile(Exiv2Image *img);
 long exiv2_image_icc_profile_size(Exiv2Image *img);
 
+void exiv2_log_msg_set_level(const int level);
+
 int exiv2_error_code(const Exiv2Error *e);
 const char *exiv2_error_what(const Exiv2Error *e);
 void exiv2_error_free(Exiv2Error *e);


### PR DESCRIPTION
I am using this package for my terminal-based picture cataloging system and I am going crazy with how much output I get when reading data from a huge image collection. I could not find another way to suppress all the output. 

Since I did never use CGO I was just more or less guessing how this would be implemented in a safe way. I tried to fiddle with the C++ Enums but I gave up and just "made it work". Implementing the callback would be over my head right now and I actually don't care too much for the errors and warnings while parsing.

I would love it if this or something similar could go into the official package so I can get rid of my fork.